### PR TITLE
When setting up a WordPress site, let the user pass in parameters to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Setting up a WordPress site could look something like this:
 --bootstrap --services \
 --letsencrypt --domain example.com --email you@example.com
 ```
+Note: For the following parameters, you can also pass your own values. If you don't, Python will generate a randomized value and use that.
+- `--wp-auth-key`
+- `--wp-secure-auth-key`
+- `--wp-logged-in-key`
+- `--wp-nonce-key`
+- `--wp-auth-salt`
+- `--wp-secure-auth-salt`
+- `--wp-logged-in-salt`
+- `--wp-nonce-salt`
+
 
 Setting up a Django app could look something like this:
 ```

--- a/ansible/roles/docker-compose/templates/docker-compose.yml.j2
+++ b/ansible/roles/docker-compose/templates/docker-compose.yml.j2
@@ -28,6 +28,14 @@ services:
       - "WORDPRESS_DB_USER=$MYSQL_USER"
       - "WORDPRESS_DB_PASSWORD=$MYSQL_PASSWORD"
       - "WORDPRESS_DB_NAME={{ db_name }}"
+      - "WORDPRESS_AUTH_KEY={{ wp_auth_key }}"
+      - "WORDPRESS_SECURE_AUTH_KEY={{ wp_secure_auth_key }}"
+      - "WORDPRESS_LOGGED_IN_KEY={{ wp_logged_in_key }}"
+      - "WORDPRESS_NONCE_KEY={{ wp_nonce_key }}"
+      - "WORDPRESS_AUTH_SALT={{ wp_auth_salt }}"
+      - "WORDPRESS_SECURE_AUTH_SALT={{ wp_secure_auth_salt }}"
+      - "WORDPRESS_LOGGED_IN_SALT={{ wp_logged_in_salt }}"
+      - "WORDPRESS_NONCE_SALT={{ wp_nonce_salt }}"
     volumes:
       - "$HOME/dawn_docker_volumes/wordpress_data:/var/www/html"
 

--- a/dawn.py
+++ b/dawn.py
@@ -21,7 +21,7 @@ import textwrap
 import shlex
 from subprocess import run, Popen, PIPE
 from time import sleep
-from random import getrandbits
+from secrets import token_hex
 
 __author__ = "Brian St. Hilailre"
 __copyright__ = "Copyright 2022, Sanctus Technologies UG (haftungsb.)"
@@ -747,7 +747,7 @@ def main():
     }
     for key, val in wordpress_secure_args.items():
         if wordpress_secure_args[key] == "":
-            wordpress_secure_args[key] = getrandbits(128)
+            wordpress_secure_args[key] = token_hex(64)
 
 
     if args.bootstrap:

--- a/dawn.py
+++ b/dawn.py
@@ -21,6 +21,7 @@ import textwrap
 import shlex
 from subprocess import run, Popen, PIPE
 from time import sleep
+from random import getrandbits
 
 __author__ = "Brian St. Hilailre"
 __copyright__ = "Copyright 2022, Sanctus Technologies UG (haftungsb.)"
@@ -61,19 +62,52 @@ def do_bootstrap(user, host):
     # so that it gets caught next time (if the host should change)
     os.system("git restore hosts")
 
-def do_services(user, host, db_root_passwd, db_user, db_passwd, db_name):
+def do_services(
+    user,
+    host,
+    db_root_passwd,
+    db_user,
+    db_passwd,
+    db_name,
+    wp_auth_key,
+    wp_secure_auth_key,
+    wp_logged_in_key,
+    wp_nonce_key,
+    wp_auth_salt,
+    wp_secure_auth_salt,
+    wp_logged_in_salt,
+    wp_nonce_salt
+):
     replace_line_in_file(dawn_path+"/ansible/hosts", "123.123.123.123", 
         host + "    ansible_python_interpreter=/usr/bin/python3")
     os.chdir(dawn_path+"/ansible")
 
     ansible_cmd = 'ansible-playbook -u {user} -i hosts playbook.yml \
         --extra-vars "db_root_passwd={db_root_passwd} \
-        db_user={db_user} db_passwd={db_passwd} db_name={db_name}"'.format(
+        db_user={db_user} \
+        db_passwd={db_passwd} \
+        db_name={db_name} \
+        wp_auth_key={wp_auth_key} \
+        wp_secure_auth_key={wp_secure_auth_key} \
+        wp_logged_in_key={wp_logged_in_key} \
+        wp_nonce_key={wp_nonce_key} \
+        wp_auth_salt={wp_auth_salt} \
+        wp_secure_auth_salt={wp_secure_auth_salt} \
+        wp_logged_in_salt={wp_logged_in_salt} \
+        wp_nonce_salt={wp_nonce_salt}"'.format(
             user=user,
             db_root_passwd=db_root_passwd,
             db_user=db_user,
             db_passwd=db_passwd,
-            db_name=db_name
+            db_name=db_name,
+            wp_auth_key=wp_auth_key,
+            wp_secure_auth_key=wp_secure_auth_key,
+            wp_logged_in_key=wp_logged_in_key,
+            wp_nonce_key=wp_nonce_key,
+            wp_auth_salt=wp_auth_salt,
+            wp_secure_auth_salt=wp_secure_auth_salt,
+            wp_logged_in_salt=wp_logged_in_salt,
+            wp_nonce_salt=wp_nonce_salt
         )
     os.system(ansible_cmd)
     os.system("git restore hosts")
@@ -425,6 +459,30 @@ def main():
         ancillary services, like phpMyAdmin, an SSH proxy for port \
         forwarding, and hidden IRC and FTP services (vestiges of some legacy \
         features of an older version of this script).")
+    parser.add_argument("--wp-auth-key", default="",
+        help="This parameter is passed into WordPress' AUTH_KEY constant. If \
+        left blank, a randomized value will be used.")
+    parser.add_argument("--wp-secure-auth-key", default="",
+        help="This parameter is passed into WordPress' SECURE_AUTH_KEY constant. If \
+        left blank, a randomized value will be used.")
+    parser.add_argument("--wp-logged-in-key", default="",
+        help="This parameter is passed into WordPress' LOGGED_IN_KEY constant. If \
+        left blank, a randomized value will be used.")
+    parser.add_argument("--wp-nonce-key", default="",
+        help="This parameter is passed into WordPress' NONCE_KEY constant. If \
+        left blank, a randomized value will be used.")
+    parser.add_argument("--wp-auth-salt", default="",
+        help="This parameter is passed into WordPress' AUTH_SALT constant. If \
+        left blank, a randomized value will be used.")
+    parser.add_argument("--wp-secure-auth-salt", default="",
+        help="This parameter is passed into WordPress' SECURE_AUTH_SALT constant. If \
+        left blank, a randomized value will be used.")
+    parser.add_argument("--wp-logged-in-salt", default="",
+        help="This parameter is passed into WordPress' LOGGED_IN_SALT constant. If \
+        left blank, a randomized value will be used.")
+    parser.add_argument("--wp-nonce-salt", default="",
+        help="This parameter is passed into WordPress' NONCE_SALT constant. If \
+        left blank, a randomized value will be used.")
     parser.add_argument("-S", "--ssl-selfsigned", action="store_true",
         help="Pass this flag to set up a self-signed SSL certificate.")
     # TODO: We should think about what we really want to do here.
@@ -677,6 +735,21 @@ def main():
     if args.django_media_directory is None:
         args.django_media_directory = "/app/" + args.app_name + "/media"
 
+    wordpress_secure_args = {
+        "wp_auth_key"        : args.wp_auth_key,
+        "wp_secure_auth_key" : args.wp_secure_auth_key,
+        "wp_logged_in_key"   : args.wp_logged_in_key,
+        "wp_nonce_key"       : args.wp_nonce_key,
+        "wp_auth_salt"       : args.wp_auth_salt,
+        "wp_secure_auth_salt": args.wp_secure_auth_salt,
+        "wp_logged_in_salt"  : args.wp_logged_in_salt,
+        "wp_nonce_salt"      : args.wp_nonce_salt,
+    }
+    for key, val in wordpress_secure_args.items():
+        if wordpress_secure_args[key] == "":
+            wordpress_secure_args[key] = getrandbits(128)
+
+
     if args.bootstrap:
         do_bootstrap(args.user, args.host)
     if args.services:
@@ -687,6 +760,14 @@ def main():
             args.database_user,
             args.database_password,
             args.database_name,
+            wordpress_secure_args['wp_auth_key'],
+            wordpress_secure_args['wp_secure_auth_key'],
+            wordpress_secure_args['wp_logged_in_key'],
+            wordpress_secure_args['wp_nonce_key'],
+            wordpress_secure_args['wp_auth_salt'],
+            wordpress_secure_args['wp_secure_auth_salt'],
+            wordpress_secure_args['wp_logged_in_salt'],
+            wordpress_secure_args['wp_nonce_salt']
         )
     if args.custom_service:
         do_custom_service(


### PR DESCRIPTION
…set the following WordPress constants: AUTH_KEY, SECURE_AUTH_KEY, LOGGED_IN_KEY, NONCE_KEY, AUTH_SALT, SECURE_AUTH_SALT, LOGGED_IN_SALT, NONCE_SALT. If those parameters are omitted, make Python generate a random value with random.getrandbits(128)